### PR TITLE
refactor: remove ?? for types unioned w undefined

### DIFF
--- a/src/media.ts
+++ b/src/media.ts
@@ -4,8 +4,7 @@ export type Mp3MetadataJson = {
   title?: string
   artist?: string
   album?: string
-  year?: string
-  comment?: string
+  year?: number
   track?: number
   genre?: string
 }
@@ -18,12 +17,11 @@ export async function parseMp3MetadataToJson(filePath: string): Promise<Mp3Metad
   const metadata = await parseFile(filePath, { duration: false })
 
   return {
-    title: metadata.common.title ?? undefined,
-    artist: metadata.common.artist ?? undefined,
-    album: metadata.common.album ?? undefined,
-    year: metadata.common.year ? String(metadata.common.year) : undefined,
-    comment: undefined,
-    track: metadata.common.track.no ?? undefined,
-    genre: metadata.common.genre?.[0] ?? undefined,
+    title: metadata.common.title,
+    artist: metadata.common.artist,
+    album: metadata.common.album,
+    year: metadata.common.year,
+    track: metadata.common.track.no ?? undefined, // track.no returns as number | null
+    genre: metadata.common.genre?.[0],
   }
 }


### PR DESCRIPTION
## Description

In parsing metadata, some of the types already return undefined if `parseFile` doesn't find anything. Thus, we can remove the ?? for these cases.

- [x] Passes tests, linting, type & formatting checks
- [x] Conventional Commits followed (PR title for squash, each commit for rebase)
