### PR TITLE
build: replace bunx with bun x for cross-platform compat

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,15 +9,15 @@
     "test:watch": "bun test --watch",
     "lint": "eslint --cache --max-warnings 0 src/ tests/",
     "lint:fix": "eslint --fix --cache --max-warnings 0 src/ tests/",
-    "typecheck": "bunx tsc --noEmit",
-    "format": "bunx prettier --check .",
-    "format:fix": "bunx prettier --write .",
+    "typecheck": "bun x tsc --noEmit",
+    "format": "bun x prettier --check .",
+    "format:fix": "bun x prettier --write .",
     "fix": "bun run lint:fix && bun run format:fix",
     "check": "bun run format && bun run lint && bun run typecheck && bun test",
     "release": "commit-and-tag-version"
   },
   "simple-git-hooks": {
-    "pre-commit": "bunx lint-staged && bun run typecheck && bun test"
+    "pre-commit": "bun x lint-staged && bun run typecheck && bun test"
   },
   "lint-staged": {
     "*.{json,md,yml,html,css}": "prettier --write",

--- a/scripts/postinstall.ts
+++ b/scripts/postinstall.ts
@@ -10,5 +10,5 @@ import { execSync } from 'child_process'
 import { existsSync } from 'fs'
 
 if (existsSync('.git')) {
-  execSync('bunx simple-git-hooks', { stdio: 'inherit' })
+  execSync('bun x simple-git-hooks', { stdio: 'inherit' })
 }


### PR DESCRIPTION
## Description

Replace `bunx` with `bun x` in `package.json` scripts and `postinstall.ts`

- `bunx` is just an alias
- There was an issue on a fresh WSL install where the alias wasn't available.

## References

Refs: [bun x docs](https://bun.sh/docs/cli/bunx)

## Checklist

- [ ] Tests added for line and branch coverage
- [x] Passes tests, linting, type & formatting checks
- [ ] New or updated decisions documented in a Decision Record
- [x] Conventional Commits followed (PR title for squash, each commit for rebase)