### PR TITLE
Feat/ Misc Frontend Changes

### DIFF
--- a/public/css/player.css
+++ b/public/css/player.css
@@ -7,6 +7,10 @@
   box-sizing: border-box;
 }
 
+html {
+  scroll-behavior: smooth;
+}
+
 body {
   font-family:
     system-ui,
@@ -16,6 +20,12 @@ body {
     Helvetica,
     Arial,
     sans-serif;
+  color: #1a1a1a;
+  background: #f5f7f5;
+  line-height: 1.6;
+  transition:
+    background 0.3s,
+    color 0.3s;
 }
 
 a {
@@ -79,153 +89,224 @@ ul {
   cursor: pointer;
 }
 
-/* Container */
-#container {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  height: 100vh;
-  padding-top: 60px;
+/* Main layout */
+#player-main {
+  max-width: 600px;
+  margin: 0 auto;
+  padding: 6rem 1.5rem 3rem;
 }
 
-#card {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  width: 400px;
-  padding: 20px;
-  border-radius: 10px;
-  background-color: #70d598;
-  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+.page-title {
+  font-size: 2rem;
+  font-weight: 800;
+  color: #08351f;
+  margin-bottom: 0.25rem;
 }
 
-#card-title {
-  margin: 0 0 16px;
-  padding: 10px 16px;
-  font-size: 27px;
+.page-subtitle {
+  color: #555;
+  margin-bottom: 2rem;
+}
+
+/* Shared panel style (matches queue/admin cards) */
+.panel {
+  background: #fff;
+  border-radius: 12px;
+  padding: 1.25rem;
+  margin-bottom: 1.5rem;
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.06);
+  display: flex;
+  flex-direction: column;
+}
+
+.panel-title {
+  font-size: 1.15rem;
   font-weight: 700;
   color: #08351f;
-  background: rgba(255, 255, 255, 0.35);
-  border: 1px solid rgba(255, 255, 255, 0.5);
-  border-radius: 12px;
-  backdrop-filter: blur(4px);
+  margin-bottom: 0.75rem;
+  padding-bottom: 0.5rem;
+  border-bottom: 2px solid #e8f5ee;
+}
+
+/* Player Card */
+#card {
+  align-items: center;
+  text-align: center;
 }
 
 #player {
+  display: none;
+}
+
+#visualizer {
+  width: 220px;
+  height: 220px;
+  margin: 0.5rem 0;
+  border-radius: 50%;
+  background: radial-gradient(
+    circle at center,
+    rgba(112, 213, 152, 0.12) 0 25%,
+    rgba(112, 213, 152, 0.05) 26% 58%,
+    rgba(8, 53, 31, 0.08) 59% 100%
+  );
+  box-shadow:
+    inset 0 0 24px rgba(112, 213, 152, 0.1),
+    0 4px 16px rgba(0, 0, 0, 0.08);
+}
+
+#player-controls {
   display: flex;
-  flex-direction: column;
   align-items: center;
-  justify-content: center;
+  gap: 1rem;
   width: 100%;
+  margin-top: 0.75rem;
 }
 
 #play {
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 60px;
-  height: 60px;
+  width: 52px;
+  height: 52px;
   border: none;
   border-radius: 50%;
-  background-color: rgba(255, 255, 255, 0.35);
+  background-color: #70d598;
   cursor: pointer;
+  transition: transform 0.15s;
+  flex-shrink: 0;
 }
 
-#visualizer {
-  width: 220px;
-  height: 220px;
-  margin: 4px 0 14px;
-  border-radius: 50%;
-  background: radial-gradient(
-    circle at center,
-    rgba(255, 255, 255, 0.2) 0 25%,
-    rgba(255, 255, 255, 0.08) 26% 58%,
-    rgba(8, 53, 31, 0.2) 59% 100%
-  );
-  box-shadow:
-    inset 0 0 24px rgba(255, 255, 255, 0.15),
-    0 8px 24px rgba(0, 0, 0, 0.15);
+#play:hover {
+  transform: scale(1.08);
 }
 
 #play-icon {
-  width: 50px;
-  height: 50px;
+  width: 30px;
+  height: 30px;
 }
 
-#below {
-  display: flex;
-  flex-direction: row;
-  align-items: flex-start;
-  justify-content: space-between;
-  gap: 20px;
-  width: 100%;
-  margin-top: 20px;
+#volume {
+  flex: 1;
+  accent-color: #70d598;
 }
 
+/* Song metadata */
 #song-meta {
   display: flex;
   flex-direction: column;
   align-items: center;
-  justify-content: center;
-  width: 50%;
-  margin-bottom: 10px;
+  gap: 0.15rem;
+  width: 100%;
+  margin-top: 0.75rem;
 }
 
 #title {
-  font-size: 22px;
-  font-weight: bold;
-  margin-bottom: 5px;
+  font-size: 1.15rem;
+  font-weight: 600;
+  color: #1a1a1a;
 }
 
 #artist,
 #album {
-  font-size: 18px;
-  margin-bottom: 5px;
+  font-size: 0.95rem;
+  color: #444;
 }
 
 #year,
 #genre {
-  display: block;
-  font-size: 16px;
-  margin-bottom: 5px;
+  font-size: 0.85rem;
+  color: #666;
 }
 
-#history {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  width: 50%;
-  margin: 0;
+/* History panel */
+.panel-history {
+  max-height: 22rem;
+}
+
+.track-list {
+  overflow-y: auto;
+  flex: 1;
   padding: 0;
-  list-style-position: inside;
+  margin: 0;
 }
 
-.history-title {
-  font-size: 18px;
-  margin-bottom: 10px;
+.track-list .empty-msg {
+  color: #999;
+  font-size: 0.9rem;
+  padding: 0.5rem 0;
 }
 
-/* Dark Mode - applied via seradio-prefs.js */
+.track-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.5rem 0.5rem;
+  border-radius: 6px;
+  transition: background 0.15s;
+  font-size: 0.9rem;
+}
+
+.track-item:hover {
+  background: #f0f7f3;
+}
+
+.track-item.now-playing {
+  background: #e8f5ee;
+  font-weight: 600;
+}
+
+.track-time {
+  flex-shrink: 0;
+  font-size: 0.8rem;
+  color: #888;
+  min-width: 5rem;
+  margin-right: 0.5rem;
+}
+
+.track-name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  flex: 1;
+  margin-right: 0.5rem;
+}
+
+.now-playing-badge {
+  font-size: 0.7rem;
+  font-weight: 700;
+  color: #08351f;
+  background: #c8f0d8;
+  padding: 0.1rem 0.4rem;
+  border-radius: 4px;
+  flex-shrink: 0;
+}
+
+/* Dark Mode */
 body.dark {
   background: #121212;
   color: #e0e0e0;
 }
 
-body.dark #card {
-  background-color: #1e3a2a;
+body.dark .page-title {
+  color: #c8f0d8;
 }
 
-body.dark #card-title {
-  color: #c8f0d8;
-  background: rgba(0, 0, 0, 0.25);
-  border-color: rgba(255, 255, 255, 0.1);
+body.dark .page-subtitle {
+  color: #aaa;
+}
+
+body.dark .panel {
+  background: #1e1e1e;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+}
+
+body.dark .panel-title {
+  color: #70d598;
+  border-bottom-color: #333;
 }
 
 body.dark #play {
-  background-color: rgba(0, 0, 0, 0.25);
+  background-color: #2d8f54;
 }
 
 body.dark #visualizer {
@@ -240,12 +321,42 @@ body.dark #visualizer {
     0 8px 24px rgba(0, 0, 0, 0.3);
 }
 
-body.dark #song-meta p,
-body.dark .history-title {
+body.dark #title {
+  color: #e0e0e0;
+}
+
+body.dark #artist,
+body.dark #album {
+  color: #bbb;
+}
+
+body.dark #year,
+body.dark #genre {
+  color: #999;
+}
+
+body.dark .track-item:hover {
+  background: #2a2a2a;
+}
+
+body.dark .track-item.now-playing {
+  background: #1a3a28;
+}
+
+body.dark .track-time {
+  color: #888;
+}
+
+body.dark .track-name {
   color: #ccc;
 }
 
-/* Mobile Responsive fully implemented with Github Copilot  */
+body.dark .now-playing-badge {
+  color: #c8f0d8;
+  background: #1a4a2e;
+}
+
+/* Mobile Responsive */
 @media (max-width: 768px) {
   .nav-links {
     display: none;
@@ -265,6 +376,10 @@ body.dark .history-title {
 
   #nav-toggle {
     display: block;
+  }
+
+  #player-main {
+    padding-top: 4.5rem;
   }
 
   #visualizer {

--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -28,7 +28,6 @@ const DEFAULTS = {
   darkMode: false,
   accentColor: '#70d598',
   defaultVolume: 80,
-  autoplay: false,
   genres: [],
   displayName: '',
   showNotifications: false,
@@ -59,7 +58,6 @@ const darkModeEl = document.getElementById('dark-mode')
 const accentColorEl = document.getElementById('accent-color')
 const defaultVolumeEl = document.getElementById('default-volume')
 const volumeLabelEl = document.getElementById('volume-label')
-const autoplayEl = document.getElementById('autoplay')
 const displayNameEl = document.getElementById('display-name')
 const showNotificationsEl = document.getElementById('show-notifications')
 const genreGridEl = document.getElementById('genre-grid')
@@ -95,9 +93,6 @@ function applySettings(settings) {
   // Volume
   defaultVolumeEl.value = settings.defaultVolume
   volumeLabelEl.textContent = settings.defaultVolume + '%'
-
-  // Autoplay
-  autoplayEl.checked = settings.autoplay
 
   // Display name
   displayNameEl.value = settings.displayName
@@ -136,7 +131,6 @@ function collectSettings() {
     darkMode: darkModeEl.checked,
     accentColor: accentColorEl.value,
     defaultVolume: Number(defaultVolumeEl.value),
-    autoplay: autoplayEl.checked,
     genres: selectedGenres,
     displayName: displayNameEl.value.trim(),
     showNotifications: showNotificationsEl.checked,
@@ -164,8 +158,6 @@ defaultVolumeEl.addEventListener('input', () => {
   volumeLabelEl.textContent = defaultVolumeEl.value + '%'
   persistAll()
 })
-
-autoplayEl.addEventListener('change', persistAll)
 
 displayNameEl.addEventListener('input', persistAll)
 

--- a/public/js/dj.js
+++ b/public/js/dj.js
@@ -20,6 +20,12 @@ const scheduleCount = document.getElementById('schedule-count')
 let editingId = null
 let toastEl = null
 
+function escapeHtml(str) {
+  const el = document.createElement('span')
+  el.textContent = str
+  return el.innerHTML
+}
+
 function slugify(value) {
   return value
     .toLowerCase()
@@ -102,16 +108,16 @@ function renderSchedule(schedule) {
       item.innerHTML = `
         <div class="schedule-meta">
           <div>
-            <p class="show-day">${show.day}</p>
-            <p class="show-name">${show.name}</p>
+            <p class="show-day">${escapeHtml(show.day)}</p>
+            <p class="show-name">${escapeHtml(show.name)}</p>
           </div>
-          <p class="show-time">${show.time}</p>
+          <p class="show-time">${escapeHtml(show.time)}</p>
         </div>
-        <p class="show-host">Hosted by ${show.host}</p>
-        <p class="show-desc">${show.desc}</p>
+        <p class="show-host">Hosted by ${escapeHtml(show.host)}</p>
+        <p class="show-desc">${escapeHtml(show.desc)}</p>
         <div class="item-actions">
-          <button class="action-link" type="button" data-action="edit" data-id="${show.id}">Edit</button>
-          <button class="action-link delete" type="button" data-action="delete" data-id="${show.id}">Remove</button>
+          <button class="action-link" type="button" data-action="edit" data-id="${escapeHtml(show.id)}">Edit</button>
+          <button class="action-link delete" type="button" data-action="delete" data-id="${escapeHtml(show.id)}">Remove</button>
         </div>
       `
       scheduleList.appendChild(item)

--- a/public/js/index.js
+++ b/public/js/index.js
@@ -6,6 +6,12 @@
 const grid = document.getElementById('schedule-grid')
 
 // Populate schedule cards from the shared schedule store
+function escapeHtml(str) {
+  const el = document.createElement('span')
+  el.textContent = str
+  return el.innerHTML
+}
+
 function renderSchedule(schedule) {
   grid.innerHTML = ''
 
@@ -21,11 +27,11 @@ function renderSchedule(schedule) {
     const card = document.createElement('div')
     card.className = 'schedule-card'
     card.innerHTML = `
-      <p class="show-day">${show.day}</p>
-      <p class="show-time">${show.time}</p>
-      <p class="show-name">${show.name}</p>
-      <p class="show-host">Hosted by ${show.host}</p>
-      <p class="show-desc">${show.desc}</p>
+      <p class="show-day">${escapeHtml(show.day)}</p>
+      <p class="show-time">${escapeHtml(show.time)}</p>
+      <p class="show-name">${escapeHtml(show.name)}</p>
+      <p class="show-host">Hosted by ${escapeHtml(show.host)}</p>
+      <p class="show-desc">${escapeHtml(show.desc)}</p>
     `
     grid.appendChild(card)
   })

--- a/public/js/player.js
+++ b/public/js/player.js
@@ -262,6 +262,7 @@ async function loadMetadata() {
 
   if (!meta.error) {
     displayMetadata(meta)
+    currentMeta = meta
   }
 }
 
@@ -269,11 +270,9 @@ async function loadMetadata() {
 loadMetadata()
 setInterval(loadMetadata, 1000)
 
-// Volume and autoplay preference js created with help from Github Copilot
-// Apply saved preferences
+// Volume preference
 if (window.seradioPrefs) {
   const prefs = window.seradioPrefs
-  // Restore volume
   const savedVol = prefs.defaultVolume / 100
   audio.volume = savedVol
   syncVisualizerGain()
@@ -281,3 +280,70 @@ if (window.seradioPrefs) {
   const percent = savedVol * 100
   volume.style.background = `linear-gradient(to right, #4CAF50 ${percent}%, #ddd ${percent}%)`
 }
+
+// History
+const historyListEl = document.getElementById('history-list')
+let currentMeta = null
+
+function renderHistory(items) {
+  const atBottom =
+    historyListEl.scrollTop + historyListEl.clientHeight >= historyListEl.scrollHeight - 4
+  historyListEl.innerHTML = ''
+
+  // Show the currently playing song as the first entry
+  if (currentMeta && !isMissing(currentMeta.title)) {
+    const li = document.createElement('li')
+    li.className = 'track-item now-playing'
+
+    const name = document.createElement('span')
+    name.className = 'track-name'
+    name.textContent =
+      currentMeta.title + (isMissing(currentMeta.artist) ? '' : ' - ' + currentMeta.artist)
+    name.title = name.textContent
+
+    const badge = document.createElement('span')
+    badge.className = 'now-playing-badge'
+    badge.textContent = 'NOW'
+
+    li.appendChild(name)
+    li.appendChild(badge)
+    historyListEl.appendChild(li)
+  }
+
+  if (items.length === 0 && !currentMeta) {
+    historyListEl.innerHTML = '<li class="empty-msg">No history yet</li>'
+    return
+  }
+
+  for (const entry of items) {
+    const li = document.createElement('li')
+    li.className = 'track-item'
+
+    const time = document.createElement('span')
+    time.className = 'track-time'
+    time.textContent = new Date(entry.timestamp).toLocaleTimeString()
+
+    const name = document.createElement('span')
+    name.className = 'track-name'
+    name.textContent = entry.file
+    name.title = entry.file
+
+    li.appendChild(time)
+    li.appendChild(name)
+    historyListEl.appendChild(li)
+  }
+  if (atBottom) historyListEl.scrollTop = historyListEl.scrollHeight
+}
+
+async function fetchHistory() {
+  try {
+    const res = await fetch('/api/queue/history?n=50')
+    const data = await res.json()
+    renderHistory((data.history || []).reverse())
+  } catch {
+    historyListEl.innerHTML = '<li class="empty-msg">Failed to load history</li>'
+  }
+}
+
+fetchHistory()
+setInterval(fetchHistory, 3000)

--- a/public/js/player.js
+++ b/public/js/player.js
@@ -257,12 +257,16 @@ function displayMetadata(meta) {
 }
 
 async function loadMetadata() {
-  const res = await fetch('/api/audio/metadata')
-  const meta = await res.json()
+  try {
+    const res = await fetch('/api/audio/metadata')
+    const meta = await res.json()
 
-  if (!meta.error) {
-    displayMetadata(meta)
-    currentMeta = meta
+    if (!meta.error) {
+      displayMetadata(meta)
+      currentMeta = meta
+    }
+  } catch {
+    // Network errors are expected when server is restarting
   }
 }
 

--- a/src/api/audio/metadata.ts
+++ b/src/api/audio/metadata.ts
@@ -13,7 +13,7 @@ metadataRouter.get('/', async (req, res, next) => {
   try {
     const filePath = nowPlaying()
     if (!filePath) {
-      res.json({ error: 'No track currently playing' })
+      res.status(404).json({ error: 'No track currently playing' })
       return
     }
     const data = await parseMp3MetadataToJson(filePath)

--- a/src/api/queue/index.ts
+++ b/src/api/queue/index.ts
@@ -1,6 +1,6 @@
 /**
  * @module api/queue
- * Mounts queue API routes under /playout prefix.
+ * Mounts queue API routes under /queue prefix.
  */
 import { Router } from 'express'
 

--- a/src/api/queue/routes.ts
+++ b/src/api/queue/routes.ts
@@ -19,7 +19,7 @@ const _basename = (p: string): string => p.split('/').pop() ?? p
 
 export const queueRouter = Router()
 
-/** GET /api/playout/on-deck - tracks already segmented, can't change. */
+/** GET /api/queue/on-deck - tracks already segmented, can't change. */
 queueRouter.get('/on-deck', (req, res) => {
   const deck = onDeck()
   res.json({
@@ -41,7 +41,7 @@ queueRouter.get('/history', async (req, res, next) => {
   }
 })
 
-/** GET /api/playout/media - list available mp3 files. */
+/** GET /api/queue/media - list available mp3 files. */
 queueRouter.get('/media', async (req, res, next) => {
   try {
     const files = await readdir(AUDIO_DIR)
@@ -52,14 +52,14 @@ queueRouter.get('/media', async (req, res, next) => {
   }
 })
 
-/** GET /api/playout/queue - return the current queue as filenames. */
+/** GET /api/queue/queue - return the current queue as filenames. */
 queueRouter.get('/queue', (req, res) => {
   const paths = queue.list()
   const items = paths.map((p) => _basename(p))
   res.json({ queue: items })
 })
 
-/** POST /api/playout/queue - append a track by filename. Body: { file: "song.mp3" } */
+/** POST /api/queue/queue - append a track by filename. Body: { file: "song.mp3" } */
 queueRouter.post('/queue', (req, res) => {
   const { file } = req.body ?? {}
   if (!file || typeof file !== 'string' || !isMp3File(file)) {
@@ -68,12 +68,18 @@ queueRouter.post('/queue', (req, res) => {
     return
   }
 
+  if (file !== path.basename(file)) {
+    logger.warn({ file }, 'queue append rejected, path traversal')
+    res.status(400).json({ error: 'file must be a plain filename' })
+    return
+  }
+
   queue.append(path.join(AUDIO_DIR, file))
   logger.info({ file }, 'track queued')
   res.json({ ok: true })
 })
 
-/** DELETE /api/playout/queue/:index - remove a track by queue position. */
+/** DELETE /api/queue/queue/:index - remove a track by queue position. */
 queueRouter.delete('/queue/:index', (req, res) => {
   const index = Number(req.params.index)
   if (!Number.isInteger(index) || index < 0) {

--- a/views/admin.eta
+++ b/views/admin.eta
@@ -46,16 +46,6 @@
       </div>
     </div>
 
-    <div class="setting-row">
-      <div class="setting-info">
-        <label for="autoplay">Autoplay on Load</label>
-        <p class="setting-desc">Automatically start playing when you open the player page.</p>
-      </div>
-      <label class="toggle-switch">
-        <input type="checkbox" id="autoplay" />
-        <span class="slider"></span>
-      </label>
-    </div>
   </section>
 
   <section class="settings-group">

--- a/views/player.eta
+++ b/views/player.eta
@@ -5,34 +5,35 @@
   scripts: '<script src="/js/player.js"></script>'
 }) %>
 
-<div id="container">
-  <div id="card">
-    <div id="card-title">SeRadio</div>
-    <audio id="player"></audio>
+<main id="player-main">
+  <h1 class="page-title">Player</h1>
+  <p class="page-subtitle">Listen live and see what's been playing.</p>
 
-    <button id="play">
-      <img id="play-icon" src="/images/play-button-svgrepo-com.svg" alt="Play" />
-    </button>
-    <input type="range" id="volume" value="1" min="0" max="1" step="0.01" />
+  <section id="card" class="panel">
+    <audio id="player"></audio>
 
     <canvas id="visualizer"></canvas>
 
-    <div id="below">
-      <div id="song-meta">
-        <p id="title"></p>
-        <p id="artist"></p>
-        <p id="album"></p>
-        <p id="year"></p>
-        <p id="genre"></p>
-      </div>
-
-      <ol id="history">
-        <p id="history1" class="history-title">History1</p>
-        <p id="history2" class="history-title">History2</p>
-        <p id="history3" class="history-title">History3</p>
-        <p id="history4" class="history-title">History4</p>
-        <p id="history5" class="history-title">History5</p>
-      </ol>
+    <div id="player-controls">
+      <button id="play">
+        <img id="play-icon" src="/images/play-button-svgrepo-com.svg" alt="Play" />
+      </button>
+      <input type="range" id="volume" value="1" min="0" max="1" step="0.01" />
     </div>
-  </div>
-</div>
+
+    <div id="song-meta">
+      <p id="title"></p>
+      <p id="artist"></p>
+      <p id="album"></p>
+      <p id="year"></p>
+      <p id="genre"></p>
+    </div>
+  </section>
+
+  <section id="history-panel" class="panel panel-history">
+    <h2 class="panel-title">History</h2>
+    <ul id="history-list" class="track-list">
+      <li class="empty-msg">No history yet</li>
+    </ul>
+  </section>
+</main>


### PR DESCRIPTION
## Description

Clean up player page and remove unused autoplay setting.

-Remove the "Autoplay on Load" toggle from the admin settings page and its JS references.
-Restyle the player page to match site conventions: Add player title + subtitle, use consistent panel styling with bordered titles, and place play button + volume slider in a horizontal control row.
-Add a history section to the player page that fetches from /api/queue/history, displays entries in reverse chronological order, and shows the currently playing song as the first item with a "NOW" badge.

## Issues

Closes #53 

## References

## Checklist

- [ ] Tests added for line and branch coverage
- [X] Passes tests, linting, type & formatting checks
- [ ] New or updated decisions documented in a Decision Record
- [X] Conventional Commits followed (PR title for squash, each commit for rebase)
